### PR TITLE
add clearTextAreas method to reset article form and response in edito…

### DIFF
--- a/ChatBot/FrontendApp/src/app/features/article/pages/editor/editor.component.ts
+++ b/ChatBot/FrontendApp/src/app/features/article/pages/editor/editor.component.ts
@@ -68,5 +68,12 @@ export default class EditorComponent implements OnInit {
     textarea.style.height = 'auto';
     textarea.style.height = `${textarea.scrollHeight}px`;
   }
+
+  clearTextAreas(): void {
+    this.articleForm.reset();
+    this.response = "";
+  }
+
+  
 }
 


### PR DESCRIPTION
This pull request adds a new method to the `EditorComponent` class to clear text areas in the article editor.

* [`ChatBot/FrontendApp/src/app/features/article/pages/editor/editor.component.ts`](diffhunk://#diff-bcc7e1e1cae3bbc2fe9a18e176a572cb8d958837f567933d199be78f933bdea8R71-R77): Added `clearTextAreas` method to reset the article form and clear the response.